### PR TITLE
v1.1.2 - update macos logic for frequency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astra"
-version = "1.1.1"
+version = "1.1.2"
 license = "MIT"
 edition = "2024"
 repository = "https://github.com/CharlieKarafotias/astra"

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,11 @@
 # Astra Release Notes
 
+## v1.1.2
+
+### Bug Fix
+- Fix issue where macOS frequency is not respected when set frequency is longer than user's normal wake session
+  - Ensure frequency means "wall time", not "active wake session" (`1d` frequency is truly 1 day)
+
 ## v1.1.1
 
 ### Bug Fix

--- a/docs/config.md
+++ b/docs/config.md
@@ -53,13 +53,32 @@ Units include seconds (`s`), minutes (`m`), hours (`h`), days (`d`), weeks (`w`)
 
 ### `frequency`
 
-Controls how often Astra automatically updates your wallpaper.  
+Controls how often Astra automatically updates your wallpaper. For example, when setting `1d` this means your wallpaper will change every day.
 Units include seconds (`s`), minutes (`m`), hours (`h`), days (`d`), weeks (`w`), months (`M`), and years (`y`).
 
 **Type:** string  
 **Format:** `^\d+[smhdwMy]$`  
 **Example:** `"1d"`  
 **Default:** Automatic updates are disabled; must run `astra` to update wallpaper.
+
+#### OS Specific Notes:
+
+##### macOS
+
+On macOS, the frequency setting is implemented using `launchd`. Internally, `astra` creates a launchd job that runs every 10 minutes.
+Each time it runs, it checks whether your configured frequency duration has elapsed.
+If it has, `astra` runs normally and applies the rest of your configuration.
+
+Because of this design, any frequency below 10 minutes is treated as 10 minutes, and any frequency that is not aligned to a 10-minute interval will still be evaluated on the next 10-minute mark.
+
+##### Windows
+
+When adjusting the frequency key on Windows, be aware that each automatic run of `astra` will briefly show a flashing Command Prompt window. This is expected behavior, as `astra` runs under the current user account.
+
+Windows also has a few scheduling limitations to consider:
+	1.	Frequencies between 1s and 60s are rounded up to 1m due to `schtasks` limitations.
+	2.	Frequencies expressed in seconds that exceed one minute (e.g., 90s) are converted to minutes and rounded (e.g., 90s becomes 1m).
+	3.	Frequencies longer than one year are reduced to 12M, because `schtasks` cannot schedule intervals greater than one year.
 
 ---
 
@@ -260,22 +279,3 @@ Optional array of RGB color arrays used when dark mode is active.
 
 ---
 
-## macOS Configuration Notes
-
-When modifying the `frequency` key on macOS, follow these steps to ensure the system daemon reloads properly:
-
-1. Remove the `frequency` key from your configuration file.
-2. Run `astra` once to unload the background service.
-3. Add `frequency` back to the file with your new desired value.
-
-## Windows Configuration Notes
-
-When modifying the `frequency` key on Windows, note that everytime the system runs astra automatically, a cmd window will flash. This is astra running as the user.
-
-Further, note there are a few limitations on Windows for frequency:
-
-1. Setting frequency between `1s` and `60s` will become `1m` on Windows due to schtasks limitation.
-2. Setting frequency with to some seconds like `90s` will convert to minutes and round (this will be `1m` on Windows).
-3. Setting frequency to anything above a year will change to `12m` as schtasks does not support higher than 1 year.
-
----

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,6 @@
 pub const QUALIFIER: &str = "dev";
 pub const ORGANIZATION: &str = "CharlieKarafotias";
 pub const APPLICATION: &str = "Astra";
+
+#[cfg(target_os = "macos")]
+pub const MAC_OS_LAUNCHCTL_INTERVAL: u64 = 600; // 10 minutes

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,14 +9,15 @@ use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 use cli::{Cli, Commands, Generator};
 use configuration::{Config, Frequency, Generators};
-use os_implementations::open_editor;
+use os_implementations::{handle_frequency, open_editor};
 use rand::random_range;
 use wallpaper_generators::{
     Color, delete_wallpapers, generate_bing_spotlight, generate_julia_set, generate_solid_color,
     handle_generate_options,
 };
 
-use crate::os_implementations::handle_frequency;
+#[cfg(target_os = "macos")]
+use os_implementations::save_last_execution_time;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
@@ -88,6 +89,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let image_type = &generators[index];
             let image_buf = image_type.with_default_mode(&config)?;
             handle_generate_options(&config, &image_buf, image_type, false, false)?;
+
+            #[cfg(target_os = "macos")]
+            save_last_execution_time()?;
         }
     };
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,15 +83,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .map(|generators| generators.to_vec())
                 .unwrap_or(Generators::ALL_GENERATORS.to_vec());
 
-            handle_frequency(&config)?;
+            // If true, then run update - else ignore
+            if handle_frequency(&config)? {
+                let index = random_range(0..generators.len());
+                let image_type = &generators[index];
+                let image_buf = image_type.with_default_mode(&config)?;
+                handle_generate_options(&config, &image_buf, image_type, false, false)?;
 
-            let index = random_range(0..generators.len());
-            let image_type = &generators[index];
-            let image_buf = image_type.with_default_mode(&config)?;
-            handle_generate_options(&config, &image_buf, image_type, false, false)?;
-
-            #[cfg(target_os = "macos")]
-            save_last_execution_time()?;
+                #[cfg(target_os = "macos")]
+                save_last_execution_time()?;
+            }
         }
     };
     Ok(())

--- a/src/os_implementations/linux/utils/mod.rs
+++ b/src/os_implementations/linux/utils/mod.rs
@@ -126,11 +126,11 @@ pub fn open_editor(config: &Config, path: PathBuf) -> Result<(), LinuxOSError> {
 ///
 /// - If key/value is defined, take the frequency and ensure astra service/timer is created/updated
 /// - If key/value is not defined, ensure the astra service/timer file is deleted (if it exists)
-pub fn handle_frequency(config: &Config) -> Result<(), LinuxOSError> {
+pub fn handle_frequency(config: &Config) -> Result<bool, LinuxOSError> {
     if let Some(frequency) = config.frequency() {
         install_astra_service_and_timer(frequency)?;
     } else {
         uninstall_astra_serivice_and_timer()?;
     }
-    Ok(())
+    Ok(true)
 }

--- a/src/os_implementations/macos/errors.rs
+++ b/src/os_implementations/macos/errors.rs
@@ -7,6 +7,7 @@ pub enum MacOSError {
     MainDisplayNotFound,
     OpenEditorError,
     OS(String),
+    ParseError(String),
     ResolutionNotFound,
     StringConversion,
     SystemProfilerError,
@@ -22,6 +23,7 @@ impl std::fmt::Display for MacOSError {
             MacOSError::MainDisplayNotFound => write!(f, "Unable to determine main display"),
             MacOSError::OpenEditorError => write!(f, "Unable to open editor"),
             MacOSError::OS(err_msg) => write!(f, "General OS error: {err_msg}"),
+            MacOSError::ParseError(err_msg) => write!(f, "Unable to parse output: {err_msg}"),
             MacOSError::ResolutionNotFound => {
                 write!(f, "Unable to determine resolution of main display")
             }

--- a/src/os_implementations/macos/launchctl.rs
+++ b/src/os_implementations/macos/launchctl.rs
@@ -1,6 +1,5 @@
-use super::super::super::Frequency;
 use super::super::MacOSError;
-use crate::constants::{APPLICATION, ORGANIZATION, QUALIFIER};
+use crate::constants::{APPLICATION, MAC_OS_LAUNCHCTL_INTERVAL, ORGANIZATION, QUALIFIER};
 use directories::UserDirs;
 use std::{fs, path::PathBuf, process::Command};
 
@@ -24,8 +23,12 @@ fn gen_plist_path() -> Result<PathBuf, MacOSError> {
 /// The file contents is used by handle_frequency function to create/update the associated astra
 /// task in launchd
 ///
+/// launchd does not support persistent durations. As such, the astra job instead runs every
+/// MAC_OS_LAUNCHCTL_INTERVAL seconds. It is then handle_frequency function's job to determine
+/// if the right amount of time has elapsed and if wallpaper should be updated by astra.
+///
 /// Resource: https://launchd.info/
-fn gen_plist_for_astra(frequency: &Frequency) -> Result<String, MacOSError> {
+fn gen_plist_for_astra() -> Result<String, MacOSError> {
     let curr_exe_path: String = std::env::current_exe()
         .map_err(|_| MacOSError::OS("failed to derive current executable path".to_string()))?
         .into_os_string()
@@ -49,7 +52,7 @@ fn gen_plist_for_astra(frequency: &Frequency) -> Result<String, MacOSError> {
         ORGANIZATION,
         APPLICATION,
         curr_exe_path,
-        frequency.to_seconds()
+        MAC_OS_LAUNCHCTL_INTERVAL,
     );
     Ok(file_contents)
 }
@@ -82,6 +85,39 @@ fn launchctl_bootout_astra(plist_path: &PathBuf) -> Result<(), MacOSError> {
     Ok(())
 }
 
+/// Runs the print command to search for existance of Astra job.
+/// IF found, will return the run interval
+/// IF NOT found, will return None
+pub(in crate::os_implementations::macos) fn launchctl_check_existance_of_astra_job()
+-> Result<Option<u64>, MacOSError> {
+    let user_id = get_user_id()?;
+    let output = Command::new("launchctl")
+        .arg("print")
+        .arg(format!(
+            "gui/{user_id}/{QUALIFIER}.{ORGANIZATION}.{APPLICATION}"
+        ))
+        .output()
+        .map_err(|e| MacOSError::Launchctl(e.to_string()))?;
+    // NOTE: any error status is interpreted as job doesn't exist and should be readded by
+    // handle_frequency
+    if !output.status.success() {
+        return Ok(None);
+    }
+    Ok(extract_interval(&output.stdout))
+}
+
+// A helper function that takes the output of launchctl print command and returns the
+// value of run interval if it exists in the output
+fn extract_interval(output: &[u8]) -> Option<u64> {
+    String::from_utf8_lossy(output)
+        .lines()
+        .find(|l| l.contains("run interval"))
+        // example line: run interval = 600 seconds
+        .and_then(|l| l.splitn(2, '=').nth(1))
+        .and_then(|l| l.trim().split_whitespace().next())
+        .and_then(|n| n.parse::<u64>().ok())
+}
+
 /// A helper function that gets the users current id
 ///
 /// Errors:
@@ -97,13 +133,18 @@ fn get_user_id() -> Result<String, MacOSError> {
     Ok(user_id)
 }
 
-pub(in crate::os_implementations::macos) fn install_astra_freq_with_launchctl(
-    frequency: &Frequency,
-) -> Result<(), MacOSError> {
+/// A helper function to create or update the plist file responsible for running astra program
+/// at a set interval (10min).
+///
+/// The function will:
+///   1. Check for the existance of the Astra job in launchctl.
+///   2. IF job exists, check that interval is 10minutes. If so then exits.
+///   3. IF update required, generates the plist file and writes it
+///   4. Then calls bootstrap to execute astra
+pub(in crate::os_implementations::macos) fn launchctl_install_astra_freq() -> Result<(), MacOSError>
+{
     let path_to_astra_plist = gen_plist_path()?;
-    let file_contents = gen_plist_for_astra(frequency)?;
-    // NOTE: - it is a known "issue" that you must turn off frequency first, run astra,
-    // then add new frequency update for launchctl to accept changes
+    let file_contents = gen_plist_for_astra()?;
     fs::write(&path_to_astra_plist, file_contents).map_err(|err_msg| {
         MacOSError::OS(format!("failed to create/update plist file: {err_msg}"))
     })?;
@@ -111,7 +152,7 @@ pub(in crate::os_implementations::macos) fn install_astra_freq_with_launchctl(
     Ok(())
 }
 
-pub(in crate::os_implementations::macos) fn uninstall_astra_freq_from_launchctl()
+pub(in crate::os_implementations::macos) fn launchctl_uninstall_astra_freq()
 -> Result<(), MacOSError> {
     let path_to_astra_plist = gen_plist_path()?;
     launchctl_bootout_astra(&path_to_astra_plist)?;
@@ -120,4 +161,46 @@ pub(in crate::os_implementations::macos) fn uninstall_astra_freq_from_launchctl(
             .map_err(|err_msg| MacOSError::OS(format!("failed to delete plist file: {err_msg}")))?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_interval_from_launchctl_output() {
+        // A minimal chunk of sample output including the line we need.
+        // You can include more if you want, but only the "run interval" line matters.
+        let sample = r#"
+gui/501/dev.CharlieKarafotias.Astra = {
+    active count = 0
+    path = /Users/someuser/Library/LaunchAgents/dev.CharlieKarafotias.Astra.plist
+    type = LaunchAgent
+
+    run interval = 86400 seconds
+
+    properties = runatload | penalty box | system service
+}
+"#;
+
+        let secs = extract_interval(sample.as_bytes());
+
+        assert_eq!(secs, Some(86400));
+    }
+
+    #[test]
+    fn test_extract_interval_from_launchctl_output_when_no_interval() {
+        let sample = r#"
+gui/501/dev.CharlieKarafotias.Astra = {
+    active count = 0
+    path = /Users/someuser/Library/LaunchAgents/dev.CharlieKarafotias.Astra.plist
+    type = LaunchAgent
+    properties = runatload | penalty box | system service
+}
+"#;
+
+        let secs = extract_interval(sample.as_bytes());
+
+        assert_eq!(secs, None)
+    }
 }

--- a/src/os_implementations/macos/utils/mod.rs
+++ b/src/os_implementations/macos/utils/mod.rs
@@ -134,11 +134,15 @@ pub fn open_editor(config: &Config, path: PathBuf) -> Result<(), MacOSError> {
 /// The job is defined in the User Agents location (~/Library/LaunchAgents/)
 pub fn handle_frequency(config: &Config) -> Result<bool, MacOSError> {
     if let Some(frequency) = config.frequency() {
-        if let Some(interval) = launchctl_check_existance_of_astra_job()?
-            && interval != MAC_OS_LAUNCHCTL_INTERVAL
-        {
-            launchctl_install_astra_freq()?;
+        match launchctl_check_existance_of_astra_job()? {
+            Some(interval) => {
+                if interval != MAC_OS_LAUNCHCTL_INTERVAL {
+                    launchctl_install_astra_freq()?;
+                }
+            }
+            None => launchctl_install_astra_freq()?,
         }
+
         let current_timestamp_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_err(|_| MacOSError::OS("time should go forward".to_string()))?

--- a/src/os_implementations/windows/utils/mod.rs
+++ b/src/os_implementations/windows/utils/mod.rs
@@ -103,11 +103,11 @@ pub(crate) fn open_editor(config: &Config, path: PathBuf) -> Result<(), WindowsE
 ///
 /// - IF key/value is defined, take the frequency and ensure astra task is created/updated
 /// - IF key/value is not defined, ensure astra task is removed from scheduled tasks
-pub(crate) fn handle_frequency(config: &Config) -> Result<(), WindowsError> {
+pub(crate) fn handle_frequency(config: &Config) -> Result<bool, WindowsError> {
     if let Some(frequency) = config.frequency() {
         install_astra_task(frequency)?;
     } else {
         uninstall_astra_task()?;
     }
-    Ok(())
+    Ok(true)
 }


### PR DESCRIPTION
# v1.1.2

## Bug Fix

- Corrects error on macOS implementation where wall clock time was not being used. 
- NOTE: highly recommend action for macOS users: removing the frequency key first, running astra command, and then re-adding the frequency key to get latest improvements. This ensures that the launchd task for astra is correctly configured